### PR TITLE
[Feat] 컨테이너 제어 API 추가 및 컨테이너 정보 수집 & 분석 관련 Dto 및 Service 수정

### DIFF
--- a/src/main/java/com/cm2/controller/ContainerController.java
+++ b/src/main/java/com/cm2/controller/ContainerController.java
@@ -1,7 +1,9 @@
 package com.cm2.controller;
 
+import com.cm2.entity.dto.ActionRequest;
+import com.cm2.entity.dto.ActionResponse;
 import com.cm2.entity.dto.ContainerDetail;
-import com.cm2.entity.dto.ContainerInfoResponse;
+import com.cm2.entity.dto.ContainerListResponse;
 import com.cm2.service.ContainerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -24,7 +26,7 @@ public class ContainerController {
             @RequestParam(value = "page", defaultValue = "1") int page) {
 
         try {
-            ContainerInfoResponse response = containerService.getContainerInfo(namespace, status, limit, page);
+            ContainerListResponse response = containerService.getContainerInfo(namespace, status, limit, page);
             if (response.getTotal() == 0)
                 return new ResponseEntity<>(HttpStatus.NO_CONTENT);
 
@@ -46,6 +48,20 @@ public class ContainerController {
 
             return new ResponseEntity<>(detail, HttpStatus.OK);
         } catch (IllegalArgumentException ex) {
+            return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+        } catch (Exception ex) {
+            return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // 컨테이너 제어 API
+    @PostMapping("/{containerId}/action")
+    public ResponseEntity<?> performAction(@PathVariable String containerId,
+                                           @RequestBody ActionRequest actionRequest) {
+        try {
+            ActionResponse response = containerService.controlContainer(containerId, actionRequest.getAction());
+            return new ResponseEntity<>(response, HttpStatus.OK);
+        } catch (IllegalArgumentException | UnsupportedOperationException ex) {
             return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
         } catch (Exception ex) {
             return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/cm2/entity/dto/ActionRequest.java
+++ b/src/main/java/com/cm2/entity/dto/ActionRequest.java
@@ -1,0 +1,16 @@
+package com.cm2.entity.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ActionRequest {
+    private String action;
+
+    @Builder
+    public ActionRequest(String action) {
+        this.action = action;
+    }
+}

--- a/src/main/java/com/cm2/entity/dto/ActionResponse.java
+++ b/src/main/java/com/cm2/entity/dto/ActionResponse.java
@@ -1,0 +1,21 @@
+package com.cm2.entity.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ActionResponse {
+    private boolean success;
+    private String message;
+    private String status;
+
+    @Builder
+    public ActionResponse(boolean success, String message, String status) {
+        this.success = success;
+        this.message = message;
+        this.status = status;
+    }
+}
+

--- a/src/main/java/com/cm2/entity/dto/ContainerDetail.java
+++ b/src/main/java/com/cm2/entity/dto/ContainerDetail.java
@@ -4,10 +4,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Collections;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
 public class ContainerDetail {
     private String id;
     private String name;
@@ -19,9 +19,21 @@ public class ContainerDetail {
     private int memoryUsage;
     private int restartCount;
 
+    // 추가 정보 : 포트, 볼륨, 환경 변수, 로그
+    @Builder.Default
+    private List<PortMapping> ports = Collections.emptyList();
+    @Builder.Default
+    private List<VolumeMapping> volumes = Collections.emptyList();
+    @Builder.Default
+    private List<EnvironmentVar> environment = Collections.emptyList();
+    @Builder.Default
+    private String logs = "";
+
     @Builder
     public ContainerDetail(String id, String name, String image, String status, String createdAt,
-                           String health, double cpuUsage, int memoryUsage, int restartCount) {
+                           String health, double cpuUsage, int memoryUsage, int restartCount,
+                           List<PortMapping> ports, List<VolumeMapping> volumes,
+                           List<EnvironmentVar> environment, String logs) {
         this.id = id;
         this.name = name;
         this.image = image;
@@ -31,5 +43,9 @@ public class ContainerDetail {
         this.cpuUsage = cpuUsage;
         this.memoryUsage = memoryUsage;
         this.restartCount = restartCount;
+        this.ports = ports == null ? Collections.emptyList() : ports;
+        this.volumes = volumes == null ? Collections.emptyList() : volumes;
+        this.environment = environment == null ? Collections.emptyList() : environment;
+        this.logs = logs == null ? "" : logs;
     }
 }

--- a/src/main/java/com/cm2/entity/dto/ContainerDetail.java
+++ b/src/main/java/com/cm2/entity/dto/ContainerDetail.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 public class ContainerDetail {
     private String id;
     private String name;

--- a/src/main/java/com/cm2/entity/dto/ContainerListResponse.java
+++ b/src/main/java/com/cm2/entity/dto/ContainerListResponse.java
@@ -8,14 +8,14 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-public class ContainerInfoResponse {
+public class ContainerListResponse {
     private int total;
     private int page;
     private int limit;
-    private List<ContainerDetail> containers;
+    private List<ContainerOverview> containers;
 
     @Builder
-    public ContainerInfoResponse(int total, int page, int limit, List<ContainerDetail> containers) {
+    public ContainerListResponse(int total, int page, int limit, List<ContainerOverview> containers) {
         this.total = total;
         this.page = page;
         this.limit = limit;

--- a/src/main/java/com/cm2/entity/dto/ContainerOverview.java
+++ b/src/main/java/com/cm2/entity/dto/ContainerOverview.java
@@ -1,0 +1,33 @@
+package com.cm2.entity.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ContainerOverview {
+    private String id;
+    private String name;
+    private String image;
+    private String status;
+    private String createdAt;
+    private String health;
+    private double cpuUsage;
+    private int memoryUsage;
+    private int restartCount;
+
+    @Builder
+    public ContainerOverview(String id, String name, String image, String status, String createdAt,
+                             String health, double cpuUsage, int memoryUsage, int restartCount) {
+        this.id = id;
+        this.name = name;
+        this.image = image;
+        this.status = status;
+        this.createdAt = createdAt;
+        this.health = health;
+        this.cpuUsage = cpuUsage;
+        this.memoryUsage = memoryUsage;
+        this.restartCount = restartCount;
+    }
+}

--- a/src/main/java/com/cm2/entity/dto/EnvironmentVar.java
+++ b/src/main/java/com/cm2/entity/dto/EnvironmentVar.java
@@ -1,0 +1,18 @@
+package com.cm2.entity.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EnvironmentVar {
+    private String key;
+    private String value;
+
+    @Builder
+    public EnvironmentVar(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/src/main/java/com/cm2/entity/dto/PortMapping.java
+++ b/src/main/java/com/cm2/entity/dto/PortMapping.java
@@ -1,0 +1,18 @@
+package com.cm2.entity.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PortMapping {
+    private int internal;
+    private int external;
+
+    @Builder
+    public PortMapping(int internal, int external) {
+        this.internal = internal;
+        this.external = external;
+    }
+}

--- a/src/main/java/com/cm2/entity/dto/VolumeMapping.java
+++ b/src/main/java/com/cm2/entity/dto/VolumeMapping.java
@@ -1,0 +1,18 @@
+package com.cm2.entity.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VolumeMapping {
+    private String source;
+    private String target;
+
+    @Builder
+    public VolumeMapping(String source, String target) {
+        this.source = source;
+        this.target = target;
+    }
+}

--- a/src/main/java/com/cm2/service/ContainerService.java
+++ b/src/main/java/com/cm2/service/ContainerService.java
@@ -11,7 +11,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -63,9 +62,7 @@ public class ContainerService {
             Process process = pb.start();
             BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
 
-            // 첫 줄은 헤더이므로 읽고 버립니다.
             String header = reader.readLine();
-            // 두 번째 줄은 실제 데이터.
             String dataLine = reader.readLine();
             process.waitFor();
 


### PR DESCRIPTION
### 추후 기능고도화할 때 캐싱 전략 고려 - 현재 ContainerService에서 getStatsForContainer는 모든 컨테이너에서 한번에 동기적으로 진행하여 프로세스의 부담이 될 수 있음 => 테스트하면서 만약 우리 CM2가 성능이 너무 안나온다면 해당 부분 바로 추가 개발하도록 하겠슴

1. 컨테이너 제어 API 추가

[모든 컨테이너 목록 조회]
<img width="1387" alt="스크린샷 2025-04-15 오후 3 07 48" src="https://github.com/user-attachments/assets/b557679f-2c2b-4f36-a0e0-7c6312eeacdd" />

[특정 컨테이너의 상세 정보 조회]
<img width="1387" alt="스크린샷 2025-04-15 오후 3 08 04" src="https://github.com/user-attachments/assets/869a4c33-ab5e-4af5-be9e-d5185cb06431" />

[컨테이너 제어 - 정지]
<img width="1387" alt="스크린샷 2025-04-15 오후 3 08 19" src="https://github.com/user-attachments/assets/917b89f2-718b-47b4-8fb3-b136d2534aff" />

[다시 특정 컨테이너의 상세 정보 조회]
<img width="1387" alt="스크린샷 2025-04-15 오후 3 08 28" src="https://github.com/user-attachments/assets/e5b203f0-bafd-4775-81a7-ad54d07fd2a9" />


2. 컨테이너 정보 수집 및 분석 관련 Dto 및 Service 리팩터링